### PR TITLE
Issue #16 - xxHash Deviations

### DIFF
--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -10,5 +10,5 @@ using System.Reflection;
 [assembly: CLSCompliant(false)]
 
 #if !CUSTOM_VERSIONING
-[assembly: AssemblyVersion("1.6.*")]
+[assembly: AssemblyVersion("1.7.*")]
 #endif

--- a/src/Test/IHashFunctionTests_HashFunctionBase.cs
+++ b/src/Test/IHashFunctionTests_HashFunctionBase.cs
@@ -1,7 +1,6 @@
 ﻿//! Automatically generated from IHashFunctionTests_HashFunctionBase.tt
 //! Direct modifications to this file will be lost.
 
-using Moq;
 using System;
 using System.Collections.Generic;
 using System.Data.HashFunction.Test.Mocks;
@@ -9,6 +8,8 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using Moq;
+using MoreLinq;
 using Xunit;
 
 namespace System.Data.HashFunction.Test
@@ -2088,9 +2089,11 @@ namespace System.Data.HashFunction.Test
                     new KnownValue(32, TestConstants.Empty, 0x02cc5d05),
                     new KnownValue(32, TestConstants.FooBar, 0xeda34aaf),
                     new KnownValue(32, TestConstants.LoremIpsum, 0x92ea46ac),
+                    new KnownValue(32, TestConstants.LoremIpsum.Take(4), 0x0df3e9ea),
                     new KnownValue(64, TestConstants.Empty, 0xef46db3751d8e999),
                     new KnownValue(64, TestConstants.FooBar, 0xa2aa05ed9085aaf9),
                     new KnownValue(64, TestConstants.LoremIpsum, 0xaf35642971419cbe),
+                    new KnownValue(64, TestConstants.LoremIpsum.Take(4), 0x103460bb4a599cab),
                 };
             }
         }

--- a/src/Test/IHashFunctionTests_HashFunctionBase.json
+++ b/src/Test/IHashFunctionTests_HashFunctionBase.json
@@ -1416,12 +1416,14 @@
                 "Async": true,
                 "ConstructionParameters": [ "hashSize" ],
                 "KnownValues":  [
-                    { "Bits": 32, "TestValue": "TestConstants.Empty",      "ExpectedValue": "0x02cc5d05" },
-                    { "Bits": 32, "TestValue": "TestConstants.FooBar",     "ExpectedValue": "0xeda34aaf" },
-                    { "Bits": 32, "TestValue": "TestConstants.LoremIpsum", "ExpectedValue": "0x92ea46ac" },
-                    { "Bits": 64, "TestValue": "TestConstants.Empty",      "ExpectedValue": "0xef46db3751d8e999" },
-                    { "Bits": 64, "TestValue": "TestConstants.FooBar",     "ExpectedValue": "0xa2aa05ed9085aaf9" },
-                    { "Bits": 64, "TestValue": "TestConstants.LoremIpsum", "ExpectedValue": "0xaf35642971419cbe" }
+                    { "Bits": 32, "TestValue": "TestConstants.Empty",               "ExpectedValue": "0x02cc5d05" },
+                    { "Bits": 32, "TestValue": "TestConstants.FooBar",              "ExpectedValue": "0xeda34aaf" },
+                    { "Bits": 32, "TestValue": "TestConstants.LoremIpsum",          "ExpectedValue": "0x92ea46ac" },
+                    { "Bits": 32, "TestValue": "TestConstants.LoremIpsum.Take(4)",  "ExpectedValue": "0x0df3e9ea" },
+                    { "Bits": 64, "TestValue": "TestConstants.Empty",               "ExpectedValue": "0xef46db3751d8e999" },
+                    { "Bits": 64, "TestValue": "TestConstants.FooBar",              "ExpectedValue": "0xa2aa05ed9085aaf9" },
+                    { "Bits": 64, "TestValue": "TestConstants.LoremIpsum",          "ExpectedValue": "0xaf35642971419cbe" },
+                    { "Bits": 64, "TestValue": "TestConstants.LoremIpsum.Take(4)",  "ExpectedValue": "0x103460bb4a599cab" }
                 ]
             },
 

--- a/src/xxHash/xxHash.cs
+++ b/src/xxHash/xxHash.cs
@@ -130,7 +130,7 @@ namespace System.Data.HashFunction
                 {
                     var h = ((UInt32) InitVal) + _primes32[4];
 
-                    int dataCount = 0;
+                    ulong dataCount = 0;
                     byte[] remainder = null;
 
 
@@ -153,13 +153,13 @@ namespace System.Data.HashFunction
                                 }
                             }
 
-                            dataCount += length;
+                            dataCount += (ulong)length;
                         },
                         (remainderData, position, length) => {
                             remainder = new byte[length];
                             Array.Copy(remainderData, position, remainder, 0, length);
 
-                            dataCount += length;
+                            dataCount += (ulong)length;
                         });
 
 
@@ -173,7 +173,7 @@ namespace System.Data.HashFunction
                 {
                      var h = InitVal + _primes64[4];
 
-                    int dataCount = 0;
+                    ulong dataCount = 0;
                     byte[] remainder = null;
 
                     var initValues = new[] {
@@ -197,13 +197,13 @@ namespace System.Data.HashFunction
                                 }
                             }
 
-                            dataCount += length;
+                            dataCount += (ulong) length;
                         },
                         (remainderData, position, length) => {
                             remainder = new byte[length];
                             Array.Copy(remainderData, position, remainder, 0, length);
 
-                            dataCount += length;
+                            dataCount += (ulong) length;
                         });
 
 
@@ -230,7 +230,7 @@ namespace System.Data.HashFunction
                 {
                     var h = ((UInt32) InitVal) + _primes32[4];
 
-                    int dataCount = 0;
+                    ulong dataCount = 0;
                     byte[] remainder = null;
 
 
@@ -253,13 +253,13 @@ namespace System.Data.HashFunction
                                 }
                             }
 
-                            dataCount += length;
+                            dataCount += (ulong) length;
                         },
                         (remainderData, position, length) => {
                             remainder = new byte[length];
                             Array.Copy(remainderData, position, remainder, 0, length);
 
-                            dataCount += length;
+                            dataCount += (ulong) length;
                         }).ConfigureAwait(false);
 
                     PostProcess(ref h, initValues, dataCount, remainder);
@@ -272,7 +272,7 @@ namespace System.Data.HashFunction
                 {
                      var h = InitVal + _primes64[4];
 
-                    int dataCount = 0;
+                    ulong dataCount = 0;
                     byte[] remainder = null;
 
                     var initValues = new[] {
@@ -295,13 +295,13 @@ namespace System.Data.HashFunction
                                 }
                             }
 
-                            dataCount += length;
+                            dataCount += (ulong) length;
                         },
                         (remainderData, position, length) => {
                             remainder = new byte[length];
                             Array.Copy(remainderData, position, remainder, 0, length);
 
-                            dataCount += remainder.Length;
+                            dataCount += (ulong) remainder.Length;
                         }).ConfigureAwait(false);
 
 
@@ -320,7 +320,7 @@ namespace System.Data.HashFunction
 #if !NET40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        private static void PostProcess(ref UInt32 h, UInt32[] initValues, int dataCount, byte[] remainder)
+        private static void PostProcess(ref UInt32 h, UInt32[] initValues, ulong dataCount, byte[] remainder)
         {
             if (dataCount >= 16)
             {
@@ -361,7 +361,7 @@ namespace System.Data.HashFunction
 #if !NET40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        private static void PostProcess(ref UInt64 h, UInt64[] initValues, int dataCount, byte[] remainder)
+        private static void PostProcess(ref UInt64 h, UInt64[] initValues, ulong dataCount, byte[] remainder)
         {
             if (dataCount >= 32)
             {
@@ -395,7 +395,7 @@ namespace System.Data.HashFunction
 
 
                 // Process a 4-byte chunk if it exists
-                if ((remainder.Length % 8) > 4)
+                if ((remainder.Length % 8) >= 4)
                 {
                     h ^= ((UInt64) BitConverter.ToUInt32(remainder, remainder.Length - (remainder.Length % 8))) * _primes64[0];
                     h  = (h.RotateLeft(23) * _primes64[1]) + _primes64[2];


### PR DESCRIPTION
xxHash calculated incorrect valuex when in 64-bit mode and the input satisfies: length % 8 == 4.
xxHash calculated incorrect values when in either mode and the input length was greater than or equal to 2^31 characters in length.

Both of these issues cause breaking changes to any current users of xxHash given the value(s) could satisfy those constraints.